### PR TITLE
Add SmartWares protocol

### DIFF
--- a/src/RCSwitch.cpp
+++ b/src/RCSwitch.cpp
@@ -126,7 +126,8 @@ static const RCSwitch::Protocol PROGMEM proto[] = {
   { 400,  0, { 0, 0 }, 1, {   1,  1 }, { 1,  2 }, { 2, 1 }, false, 43 },  // 31 (Mertik Maxitrol G6R-H4T1)
   { 365,  0, { 0, 0 }, 1, {  18,  1 }, { 3,  1 }, { 1, 3 }, true,   0 },  // 32 (1ByOne Doorbell) from @Fatbeard https://github.com/sui77/rc-switch/pull/277
   { 340,  0, { 0, 0 }, 1, {  14,  4 }, { 1,  2 }, { 2, 1 }, false,  0 },  // 33 (Dooya Control DC2708L)
-  { 120,  0, { 0, 0 }, 1, {   1, 28 }, { 1,  3 }, { 3, 1 }, false,  0 }   // 34 DIGOO SD10
+  { 120,  0, { 0, 0 }, 1, {   1, 28 }, { 1,  3 }, { 3, 1 }, false,  0 },  // 34 DIGOO SD10
+  { 275,  0, { 0, 0 }, 1, {   1, 10 }, { 1,  1 }, { 1, 5 }, false, 37 }   // 35 (SmartWares/HomeEasy)
 };
 
 enum {


### PR DESCRIPTION
Added protocol for SmartWares "learning" plugs. These are plugs, seemingly mostly available in Europe. The plugs can be associated/disassociated from the remote. They can associate several remotes.

The code is 64 pulses long, which are combined 2-by-2 (like the other protocols) to make a 32 bits word. It is decomposed into a remote ID, a flag to activate one plug or all associated plugs, a flag for ON/OFF and 4 bits to code the plug index, accommodating up to 16 plugs.

More information: https://github.com/sui77/rc-switch/issues/360

- 0 is 275µs high, 240µs low, simplified {1, 1} Te.
- 1 is 275µs high, 1330µs low, simplified {1, 5} Te.
- Needs a sync bit of 275µs high and 2550µs low, simplified {1, 10} Te.
- Requires at least 10000µs low between repeats, simplified 37 Te.
- Requires a 65th pulse for validation (So KeeLoq workaround is important).
