### PR TITLE
Add getNumProtocols method

### DIFF
--- a/src/RCSwitch.cpp
+++ b/src/RCSwitch.cpp
@@ -188,6 +188,12 @@ void RCSwitch::setProtocol(int nProtocol, int nPulseLength) {
   this->setPulseLength(nPulseLength);
 }
 
+/**
+  * Get the number of supported protocols (maximum index)
+  */
+const int RCSwitch::getNumProtocols(void) {
+  return numProto;
+}
 
 /**
   * Sets pulse length in microseconds

--- a/src/RCSwitch.h
+++ b/src/RCSwitch.h
@@ -152,6 +152,7 @@ class RCSwitch {
     void setProtocol(Protocol protocol);
     void setProtocol(int nProtocol);
     void setProtocol(int nProtocol, int nPulseLength);
+    const int getNumProtocols(void);
 
   private:
     char* getCodeWordA(const char* sGroup, const char* sDevice, bool bStatus);


### PR DESCRIPTION
Returns the number of supported protocols.

This is a features that comes at hand for validation of inputs, when for example driving the RCSwitch library from Serial.

Not much to say, it just returns the internal constant "numProto".